### PR TITLE
feat(mc_check): 优化域名处理

### DIFF
--- a/mc_check/configs.py
+++ b/mc_check/configs.py
@@ -12,4 +12,4 @@ def readInfo(file: str) -> dict:
 message_type = Config.get_config("mc_check", "type", 0)
 lang = Config.get_config("mc_check", "LANGUAGE", "zh-cn")
 lang_data = readInfo("language.json")
-VERSION = "1.31"
+VERSION = "1.32"

--- a/mc_check/utils.py
+++ b/mc_check/utils.py
@@ -66,9 +66,11 @@ async def build_result(ms, address, type=0):
             "gamemode": ms.gamemode,
             "motd": await parse_motd2html(ms.motd),
             "players": f"{ms.current_players}/{ms.max_players}",
-            "player_list": await parse_motd2html("§r, ".join(ms.player_list))
-            if ms.player_list
-            else None,
+            "player_list": (
+                await parse_motd2html("§r, ".join(ms.player_list))
+                if ms.player_list
+                else None
+            ),
             "lang": lang_data[lang],
             "VERSION": VERSION,
         }
@@ -141,9 +143,11 @@ async def get_mc(
             await asyncio.to_thread(get_java, ip, port, ip_type, refer, timeout)
         ]
 
-    return await asyncio.gather(
-        asyncio.to_thread(get_java, ip, port, ip_type, refer, timeout),
-        asyncio.to_thread(get_bedrock, ip, port, ip_type, refer, timeout),
+    return list(
+        await asyncio.gather(
+            asyncio.to_thread(get_java, ip, port, ip_type, refer, timeout),
+            asyncio.to_thread(get_bedrock, ip, port, ip_type, refer, timeout),
+        )
     )
 
 
@@ -308,16 +312,15 @@ async def is_domain(address: str) -> bool:
     返回:
     bool: 如果地址为域名则返回True，否则返回False。
     """
-    if address.lower() == "localhost":
-        return True
-    domain_pattern = re.compile(
-        r"^(?!-)(?:[A-Za-z0-9-]{1,63}\.)+(?:[A-Za-z]{2,})$|^(xn--[A-Za-z0-9-]{1,63})\.[A-Za-z]{2,}$"
-    )
     try:
         punycode_address = idna.encode(address).decode("utf-8")
-        return bool(domain_pattern.match(punycode_address))
     except idna.IDNAError:
         return False
+
+    domain_pattern = re.compile(
+        r"^(?!-)(?:[A-Za-z0-9-]{1,63}\.)+(?:[A-Za-z]{2,}|xn--[A-Za-z0-9-]{2,})$|^(localhost)$"
+    )
+    return bool(domain_pattern.match(punycode_address))
 
 
 async def is_ipv4(address: str) -> bool:
@@ -390,8 +393,13 @@ async def get_origin_address(
       - 第四个元素是解析地址的来源域名或IP
     """
     ip_type = await get_ip_type(domain)
+    try:
+        refer_domain = idna.encode(domain).decode("utf-8")
+    except idna.IDNAError:
+        refer_domain = domain
+
     if ip_type != "Domain":
-        return [(domain, ip_port, ip_type, domain)]
+        return [(domain, ip_port, ip_type, refer_domain)]
     data = []
 
     resolver = dns.asyncresolver.Resolver()
@@ -411,6 +419,10 @@ async def get_origin_address(
                 srv_address = str(rdata.target).rstrip(".")  # type: ignore
                 srv_port = rdata.port  # type: ignore
                 ip_type = await get_ip_type(srv_address)
+                try:
+                    srv_refer = idna.encode(srv_address).decode("utf-8")
+                except idna.IDNAError:
+                    srv_refer = srv_address
                 if ip_type == "Domain":
                     srv_address_ = await get_origin_address(
                         srv_address, srv_port, False
@@ -421,18 +433,12 @@ async def get_origin_address(
                         f"SRV-{srv_address_[0][2]}",
                         srv_address_[0][3],
                     )
-                    # data.extend(
-                    #     [
-                    #         (addr, port, f"SRV-{ip_type}", refer)
-                    #         for addr, port, ip_type, refer in srv_address_
-                    #     ]
-                    # )
                 else:
                     srv_data = (
                         srv_address,
                         srv_port,
                         f"SRV-{ip_type}",
-                        domain,
+                        srv_refer,
                     )
                 if not any(
                     entry[0] == srv_data[0]
@@ -452,7 +458,7 @@ async def get_origin_address(
         ):
             response = await resolver.resolve(domain, "AAAA")
             for rdata in response:
-                data.append((str(rdata.address), ip_port, "IPv6", domain))  # type: ignore
+                data.append((str(rdata.address), ip_port, "IPv6", refer_domain))  # type: ignore
                 break
 
     async def resolve_a():
@@ -464,7 +470,7 @@ async def get_origin_address(
         ):
             response = await resolver.resolve(domain, "A")
             for rdata in response:
-                data.append((str(rdata.address), ip_port, "IPv4", domain))  # type: ignore
+                data.append((str(rdata.address), ip_port, "IPv4", refer_domain))  # type: ignore
                 break
 
     if is_resolve_srv:
@@ -637,6 +643,7 @@ async def parse_motd2html(data: str | None) -> str | None:
         return await parse_text_motd(data)
 
     return await parse_json_motd(data)
+
 
 def is_qbot(session: Uninfo) -> bool:
     """判断bot是否为qq官bot


### PR DESCRIPTION
- 将版本号从 1.31 升级到 1.32
- 优化了域名解析和处理逻辑
- 改进了玩家列表的显示方式
- 修复了一些潜在的编码问题

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

优化域名处理逻辑，更新了正则表达式和 punycode 后备方案；在地址解析过程中传递 refer 域名；改进了玩家列表的格式；并将版本提升至 1.32。

Bug 修复：
- 为 IDNA 编码错误提供后备方案，以防止解析失败
- 在域名检测中包含“localhost”，以正确对其进行分类

增强功能：
- 通过整合的正则表达式和 IDNA 编码地址的后备方案，改进域名验证
- 在所有地址解析路径（SRV、A、AAAA）中传递 punycode 编码的 refer_domain
- 从 get_mc 返回一个列表而不是一个元组，以保持输出一致
- 重构 player_list 生成格式，以清理条件表达式

构建：
- 将 mc_check 版本从 1.31 提升至 1.32

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize domain handling logic with updated regex and punycode fallback, propagate refer domains during address resolution, refine player list formatting, and bump version to 1.32.

Bug Fixes:
- Provide fallback for IDNA encoding errors to prevent resolution failures
- Include “localhost” in domain detection to correctly classify it

Enhancements:
- Improve domain validation with a consolidated regex and fallback for IDNA-encoded addresses
- Propagate punycode-encoded refer_domain in all address resolution paths (SRV, A, AAAA)
- Return a list instead of a tuple from get_mc for consistent output
- Refactor player_list generation formatting to clean up the conditional expression

Build:
- Bump mc_check version from 1.31 to 1.32

</details>